### PR TITLE
docs: アクセス制御表の追加

### DIFF
--- a/src/authorization.md
+++ b/src/authorization.md
@@ -3,7 +3,7 @@
 ## アカウントのロール
 
 ロールはアカウントに対する権限の集合を示すものである.\
-複数のロールを持つことはできず、1つのアカウントに対して1つのロールが設定される.\  
+複数のロールを持つことはできず、1つのアカウントに対して1つのロールが設定される.\\
 以下にロールの種類を示す．
 
 ### Admin (管理者)
@@ -52,7 +52,8 @@
 
 凍結済み状態.\
 ログインを含む全ての操作が**実行不可能**.\
-そのアカウントの投稿, メディアは`Admin`/`Moderator`ロール以外のアカウントから閲覧できなくなる.
+そのアカウントの投稿,
+メディアは`Admin`/`Moderator`ロール以外のアカウントから閲覧できなくなる.
 
 > [!IMPORTANT]
 >
@@ -71,7 +72,8 @@
 
 ### 凡例
 
-操作が可能であれば`Yes`, 不可能であれば`No`と表記する．他人のリソースに対する操作が可能な場合は`Yes*`と表記する\
+操作が可能であれば`Yes`,
+不可能であれば`No`と表記する．他人のリソースに対する操作が可能な場合は`Yes*`と表記する\
 `-`は該当しない場合を示す．\
 特殊な制御がある場合は具体的に記述する．\
 
@@ -81,82 +83,75 @@
 - `Not Signed in` ログインしていない状態
 
 |        操作        | Status:Active | Status:NotActivated | Role:Normal | Role:Moderator | Role:Admin | Frozen:Frozen | Not Signed in | 備考 |
-|:----------------:|:-------------:|:-------------------:|:-----------:|:--------------:|:----------:|:-------------:|:-------------:|:--:|
-| Note::Create(投稿) |      Yes      |         No          |     Yes     |      Yes       |    Yes     |      No       |               |    |
+| :----------------: | :-----------: | :-----------------: | :---------: | :------------: | :--------: | :-----------: | :-----------: | :--: |
+| Note::Create(投稿) |      Yes      |         No          |     Yes     |      Yes       |    Yes     |      No       |               |      |
 
 ### Account
 
-|            操作            | Status:Active | Status:NotActivated | Role:Normal |      Role:Moderator       |         Role:Admin          | Frozen:Frozen |            Not Signed in            | 備考 |
-|:------------------------:|:-------------:|:-------------------:|:-----------:|:-------------------------:|:---------------------------:|:-------------:|:-----------------------------------:|:--:|
-|    Account::Register     |       -       |          -          |      -      |             -             |              -              |       -       | Yes(登録が解放されている場合) No(登録が解放されていない場合) |    |
-|      Account::Edit       |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |                 No                  |    |
-|     Account::Freeze      |      No       |         No          |     No      | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |                 No                  |    |
-|    Account::Unfreeze     |      No       |         No          |     No      | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |                 No                  |    |
-|      Account::Fetch      |      Yes      |         Yes         |     Yes     |            Yes            |             Yes             |      No       |                 Yes                 |    |
-|     Account::Silence     |      No       |         No          |     No      | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |                 No                  |    |
-|   Account::UndoSilence   |      No       |         No          |     No      | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |                 No                  |    |
-|     Account::Follow      |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |                 No                  |    |
-|    Account::Unfollow     |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |                 No                  |    |
-| Account::FetchFollowings |      Yes      |         Yes         |     Yes     |            Yes            |             Yes             |      No       |                 No                  |    |
-| Account::FetchFollowers  |      Yes      |         Yes         |     Yes     |            Yes            |             Yes             |      No       |                 No                  |    |
-|    Account::SetAvatar    |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |                 No                  |    |
-|    Account::SetHeader    |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |                 No                  |    |
-|   Account::UnsetAvatar   |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |                 No                  |    |
-|   Account::UnsetHeader   |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |                 No                  |    |
+|           操作           | Status:Active | Status:NotActivated | Role:Normal |          Role:Moderator           |             Role:Admin             | Frozen:Frozen |                        Not Signed in                         | 備考 |
+| :----------------------: | :-----------: | :-----------------: | :---------: | :-------------------------------: | :--------------------------------: | :-----------: | :----------------------------------------------------------: | :--: |
+|    Account::Register     |       -       |          -          |      -      |                 -                 |                 -                  |       -       | Yes(登録が解放されている場合) No(登録が解放されていない場合) |      |
+|      Account::Edit       |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |                              No                              |      |
+|     Account::Freeze      |      No       |         No          |     No      | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |                              No                              |      |
+|    Account::Unfreeze     |      No       |         No          |     No      | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |                              No                              |      |
+|      Account::Fetch      |      Yes      |         Yes         |     Yes     |                Yes                |                Yes                 |      No       |                             Yes                              |      |
+|     Account::Silence     |      No       |         No          |     No      | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |                              No                              |      |
+|   Account::UndoSilence   |      No       |         No          |     No      | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |                              No                              |      |
+|     Account::Follow      |      Yes      |         No          |     Yes     |                Yes                |                Yes                 |      No       |                              No                              |      |
+|    Account::Unfollow     |      Yes      |         No          |     Yes     |                Yes                |                Yes                 |      No       |                              No                              |      |
+| Account::FetchFollowings |      Yes      |         Yes         |     Yes     |                Yes                |                Yes                 |      No       |                              No                              |      |
+| Account::FetchFollowers  |      Yes      |         Yes         |     Yes     |                Yes                |                Yes                 |      No       |                              No                              |      |
+|    Account::SetAvatar    |      Yes      |         No          |     Yes     |                Yes                |                Yes                 |      No       |                              No                              |      |
+|    Account::SetHeader    |      Yes      |         No          |     Yes     |                Yes                |                Yes                 |      No       |                              No                              |      |
+|   Account::UnsetAvatar   |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |                              No                              |      |
+|   Account::UnsetHeader   |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |                              No                              |      |
 
 ### Note
 
-|        操作        | Status:Active | Status:NotActivated | Role:Normal |      Role:Moderator       |         Role:Admin          | Frozen:Frozen | Not Signed in | 備考 |
-|:----------------:|:-------------:|:-------------------:|:-----------:|:-------------------------:|:---------------------------:|:-------------:|:-------------:|:--:|
-|   Note::Create   |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |      No       |    |
-|   Note::Fetch    |      Yes      |         Yes         |     Yes     |            Yes            |             Yes             |      No       |      Yes      |    | 
-|   Note::Renote   |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |      No       |    |
-|   Note::Delete   |      Yes      |         Yes         |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |    |
-| Bookmark::Create |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |      No       |    |
-| Bookmark::Fetch  |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |      No       |    |
-| Bookmark::Delete |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |      No       |    |
-| Reaction::Create |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |      No       |    |
-| Reaction::Fetch  |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      Yes      |    |
-| Reaction::Delete |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |    |
+|       操作       | Status:Active | Status:NotActivated | Role:Normal |          Role:Moderator           |             Role:Admin             | Frozen:Frozen | Not Signed in | 備考 |
+| :--------------: | :-----------: | :-----------------: | :---------: | :-------------------------------: | :--------------------------------: | :-----------: | :-----------: | :--: |
+|   Note::Create   |      Yes      |         No          |     Yes     |                Yes                |                Yes                 |      No       |      No       |      |
+|   Note::Fetch    |      Yes      |         Yes         |     Yes     |                Yes                |                Yes                 |      No       |      Yes      |      |
+|   Note::Renote   |      Yes      |         No          |     Yes     |                Yes                |                Yes                 |      No       |      No       |      |
+|   Note::Delete   |      Yes      |         Yes         |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |      |
+| Bookmark::Create |      Yes      |         No          |     Yes     |                Yes                |                Yes                 |      No       |      No       |      |
+| Bookmark::Fetch  |      Yes      |         No          |     Yes     |                Yes                |                Yes                 |      No       |      No       |      |
+| Bookmark::Delete |      Yes      |         No          |     Yes     |                Yes                |                Yes                 |      No       |      No       |      |
+| Reaction::Create |      Yes      |         No          |     Yes     |                Yes                |                Yes                 |      No       |      No       |      |
+| Reaction::Fetch  |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      Yes      |      |
+| Reaction::Delete |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |      |
 
-備考: Bookmark::Fetch/Deleteはモデレーション処理を行う必要性が薄いためモデレーションの対象外とした．
+備考:
+Bookmark::Fetch/Deleteはモデレーション処理を行う必要性が薄いためモデレーションの対象外とした．
 
 ### Drive/Medium
 
-|        操作         | Status:Active | Status:NotActivated | Role:Normal |      Role:Moderator       |         Role:Admin          | Frozen:Frozen | Not Signed in | 備考 |
-|:-----------------:|:-------------:|:-------------------:|:-----------:|:-------------------------:|:---------------------------:|:-------------:|:-------------:|:--:|
-|  Medium::Upload   |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |      No       |    |
-| Medium::FetchList |      Yes      |         Yes         |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |    |
-|   Medium::Fetch   |      Yes      |         Yes         |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |    |
-|  Medium::Delete   |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |    |
+|       操作        | Status:Active | Status:NotActivated | Role:Normal |          Role:Moderator           |             Role:Admin             | Frozen:Frozen | Not Signed in | 備考 |
+| :---------------: | :-----------: | :-----------------: | :---------: | :-------------------------------: | :--------------------------------: | :-----------: | :-----------: | :--: |
+|  Medium::Upload   |      Yes      |         No          |     Yes     |                Yes                |                Yes                 |      No       |      No       |      |
+| Medium::FetchList |      Yes      |         Yes         |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |      |
+|   Medium::Fetch   |      Yes      |         Yes         |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |      |
+|  Medium::Delete   |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |      |
 
 ### Timeline/List
 
-|               操作                | Status:Active | Status:NotActivated | Role:Normal |      Role:Moderator       |         Role:Admin          | Frozen:Frozen | Not Signed in | 備考 |
-|:-------------------------------:|:-------------:|:-------------------:|:-----------:|:-------------------------:|:---------------------------:|:-------------:|:-------------:|:--:|
-|       Timeline::FetchHome       |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |      No       |    |
-|     Timeline::FetchAccount      |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |    |
-|       Timeline::FetchList       |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |    |
-|      Timeline::CreateList       |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |      No       |    |
-|           List::Edit            |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |    |
-|          List::Delete           |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |    |
-|       List::AssignMember        |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |      No       |    |
-|      List::UnassignMember       |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |      No       |    |
-|       List::FetchMembers        |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |    |
-| Timeline::FetchConversationList |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |      No       |    |
-|   Timeline::FetchConversation   |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |    |
+|              操作               | Status:Active | Status:NotActivated | Role:Normal |          Role:Moderator           |             Role:Admin             | Frozen:Frozen | Not Signed in | 備考 |
+| :-----------------------------: | :-----------: | :-----------------: | :---------: | :-------------------------------: | :--------------------------------: | :-----------: | :-----------: | :--: |
+|       Timeline::FetchHome       |      Yes      |         No          |     Yes     |                Yes                |                Yes                 |      No       |      No       |      |
+|     Timeline::FetchAccount      |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |      |
+|       Timeline::FetchList       |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |      |
+|      Timeline::CreateList       |      Yes      |         No          |     Yes     |                Yes                |                Yes                 |      No       |      No       |      |
+|           List::Edit            |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |      |
+|          List::Delete           |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |      |
+|       List::AssignMember        |      Yes      |         No          |     Yes     |                Yes                |                Yes                 |      No       |      No       |      |
+|      List::UnassignMember       |      Yes      |         No          |     Yes     |                Yes                |                Yes                 |      No       |      No       |      |
+|       List::FetchMembers        |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |      |
+| Timeline::FetchConversationList |      Yes      |         No          |     Yes     |                Yes                |                Yes                 |      No       |      No       |      |
+|   Timeline::FetchConversation   |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |      |
 
 ### Notification
 
-|               操作                | Status:Active | Status:NotActivated | Role:Normal | Role:Moderator | Role:Admin | Frozen:Frozen | Not Signed in | 備考 |
-|:-------------------------------:|:-------------:|:-------------------:|:-----------:|:--------------:|:----------:|:-------------:|:-------------:|:--:|
-| Notification::FetchNotification |      Yes      |         No          |     Yes     |      Yes       |    Yes     |      No       |      No       |    |
-|    Notification::MarkAsRead     |      Yes      |         No          |     Yes     |      Yes       |    Yes     |      No       |      No       |    |
-
-
-
-
-
-
-
-
+|              操作               | Status:Active | Status:NotActivated | Role:Normal | Role:Moderator | Role:Admin | Frozen:Frozen | Not Signed in | 備考 |
+| :-----------------------------: | :-----------: | :-----------------: | :---------: | :------------: | :--------: | :-----------: | :-----------: | :--: |
+| Notification::FetchNotification |      Yes      |         No          |     Yes     |      Yes       |    Yes     |      No       |      No       |      |
+|    Notification::MarkAsRead     |      Yes      |         No          |     Yes     |      Yes       |    Yes     |      No       |      No       |      |

--- a/src/authorization.md
+++ b/src/authorization.md
@@ -1,38 +1,20 @@
-# アクセス制御
+# アクセス制御について
 
 ## アカウントのロール
 
-ロールは自分以外のアカウントに対して操作を実行可能であるかを制御する.
-
-表1: 可能な操作一覧
-
-|      操作名      |                     備考                     | `Admin` | `Moderator` |
-| :--------------: | :------------------------------------------: | :-----: | :---------: |
-|   他アカウント   | 凍結、サイレンスの実行、アカウント情報の閲覧 |    Y    |      Y      |
-| ノート/メディア  |            ノート/メディアの削除             |    Y    |      Y      |
-| 通報に関する操作 |         通報の確認/解決、警告の送信          |    Y    |      Y      |
-| 不要メディア削除 |     どこからも参照されないメディアの削除     |    Y    |      N      |
-|     統計情報     |              稼働統計情報の閲覧              |    Y    |      Y      |
-|   システム設定   |              設定値の閲覧/変更               |    Y    |      N      |
-|     お知らせ     |             お知らせの送信、編集             |    Y    |      N      |
-|  カスタム絵文字  |              登録、無効化、削除              |    Y    |      Y      |
-|  他インスタンス  |      インスタンスのサイレンス/ブロック       |    Y    |      N      |
-
-※ Y: 操作、閲覧が可能 / N: 操作、閲覧が不可能
+ロールはアカウントに対する権限の集合を示すものである.\
+複数のロールを持つことはできず、1つのアカウントに対して1つのロールが設定される.\  
+以下にロールの種類を示す．
 
 ### Admin (管理者)
 
 管理者.\
-全ての操作が実行可能.
+他のロールを持つアカウントの状態を変更することができる．
 
 ### Moderator (モデレーター)
 
 モデレーター.\
-(自他問わず)インスタンス、お知らせ以外の操作を実行可能
-
-> [!IMPORTANT]
->
-> モデレーターは一般ロールのアカウントに対する操作のみ実行可能.
+一般ロールのアカウントの状態を変更することができる．
 
 ### Normal (一般)
 
@@ -43,17 +25,14 @@
 
 メールアドレスの検証が行われたかを示すもの.
 
-### notActivated (メールアドレス未検証)
+### NotActivated (メールアドレス未検証)
 
 メールアドレスの検証が行われていない状態.\
-検証が行われていないアカウントは一定期間(設定可能)経過後に自動で削除される(設定で行わないことも可能)
-
-メールアドレス検証トークンの再送信のリクエスト と アカウント削除 のみ実行可能.
+アカウント作成直後はこの状態になり，アカウントにログインすることはできない．
 
 ### Active (メールアドレス検証済み)
 
 メールアドレスの検証が行われたことを示す状態.
-
 設定されているロールの権限に基づく全ての操作が実行可能になる.
 
 ## アカウント状態
@@ -73,8 +52,7 @@
 
 凍結済み状態.\
 ログインを含む全ての操作が**実行不可能**.\
-そのアカウントの投稿,
-メディアは`Admin`/`Moderator`ロール以外のアカウントから閲覧できなくなる.
+そのアカウントの投稿, メディアは`Admin`/`Moderator`ロール以外のアカウントから閲覧できなくなる.
 
 > [!IMPORTANT]
 >
@@ -88,3 +66,97 @@
 > [!IMPORTANT]
 >
 > サイレンス状態が解除されても、サイレンス中に行われた投稿の公開範囲は変更されない.
+
+## アクセス制御表
+
+### 凡例
+
+操作が可能であれば`Yes`, 不可能であれば`No`と表記する．他人のリソースに対する操作が可能な場合は`Yes*`と表記する\
+`-`は該当しない場合を示す．\
+特殊な制御がある場合は具体的に記述する．\
+
+- `Status:*` メールアドレスの検証状態
+- `Role:*` アカウントのロール
+- `Frozen:*` アカウントの状態
+- `Not Signed in` ログインしていない状態
+
+|        操作        | Status:Active | Status:NotActivated | Role:Normal | Role:Moderator | Role:Admin | Frozen:Frozen | Not Signed in | 備考 |
+|:----------------:|:-------------:|:-------------------:|:-----------:|:--------------:|:----------:|:-------------:|:-------------:|:--:|
+| Note::Create(投稿) |      Yes      |         No          |     Yes     |      Yes       |    Yes     |      No       |               |    |
+
+### Account
+
+|            操作            | Status:Active | Status:NotActivated | Role:Normal |      Role:Moderator       |         Role:Admin          | Frozen:Frozen |            Not Signed in            | 備考 |
+|:------------------------:|:-------------:|:-------------------:|:-----------:|:-------------------------:|:---------------------------:|:-------------:|:-----------------------------------:|:--:|
+|    Account::Register     |       -       |          -          |      -      |             -             |              -              |       -       | Yes(登録が解放されている場合) No(登録が解放されていない場合) |    |
+|      Account::Edit       |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |                 No                  |    |
+|     Account::Freeze      |      No       |         No          |     No      | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |                 No                  |    |
+|    Account::Unfreeze     |      No       |         No          |     No      | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |                 No                  |    |
+|      Account::Fetch      |      Yes      |         Yes         |     Yes     |            Yes            |             Yes             |      No       |                 Yes                 |    |
+|     Account::Silence     |      No       |         No          |     No      | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |                 No                  |    |
+|   Account::UndoSilence   |      No       |         No          |     No      | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |                 No                  |    |
+|     Account::Follow      |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |                 No                  |    |
+|    Account::Unfollow     |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |                 No                  |    |
+| Account::FetchFollowings |      Yes      |         Yes         |     Yes     |            Yes            |             Yes             |      No       |                 No                  |    |
+| Account::FetchFollowers  |      Yes      |         Yes         |     Yes     |            Yes            |             Yes             |      No       |                 No                  |    |
+|    Account::SetAvatar    |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |                 No                  |    |
+|    Account::SetHeader    |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |                 No                  |    |
+|   Account::UnsetAvatar   |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |                 No                  |    |
+|   Account::UnsetHeader   |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |                 No                  |    |
+
+### Note
+
+|        操作        | Status:Active | Status:NotActivated | Role:Normal |      Role:Moderator       |         Role:Admin          | Frozen:Frozen | Not Signed in | 備考 |
+|:----------------:|:-------------:|:-------------------:|:-----------:|:-------------------------:|:---------------------------:|:-------------:|:-------------:|:--:|
+|   Note::Create   |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |      No       |    |
+|   Note::Fetch    |      Yes      |         Yes         |     Yes     |            Yes            |             Yes             |      No       |      Yes      |    | 
+|   Note::Renote   |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |      No       |    |
+|   Note::Delete   |      Yes      |         Yes         |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |    |
+| Bookmark::Create |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |      No       |    |
+| Bookmark::Fetch  |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |      No       |    |
+| Bookmark::Delete |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |      No       |    |
+| Reaction::Create |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |      No       |    |
+| Reaction::Fetch  |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      Yes      |    |
+| Reaction::Delete |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |    |
+
+備考: Bookmark::Fetch/Deleteはモデレーション処理を行う必要性が薄いためモデレーションの対象外とした．
+
+### Drive/Medium
+
+|        操作         | Status:Active | Status:NotActivated | Role:Normal |      Role:Moderator       |         Role:Admin          | Frozen:Frozen | Not Signed in | 備考 |
+|:-----------------:|:-------------:|:-------------------:|:-----------:|:-------------------------:|:---------------------------:|:-------------:|:-------------:|:--:|
+|  Medium::Upload   |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |      No       |    |
+| Medium::FetchList |      Yes      |         Yes         |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |    |
+|   Medium::Fetch   |      Yes      |         Yes         |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |    |
+|  Medium::Delete   |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |    |
+
+### Timeline/List
+
+|               操作                | Status:Active | Status:NotActivated | Role:Normal |      Role:Moderator       |         Role:Admin          | Frozen:Frozen | Not Signed in | 備考 |
+|:-------------------------------:|:-------------:|:-------------------:|:-----------:|:-------------------------:|:---------------------------:|:-------------:|:-------------:|:--:|
+|       Timeline::FetchHome       |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |      No       |    |
+|     Timeline::FetchAccount      |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |    |
+|       Timeline::FetchList       |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |    |
+|      Timeline::CreateList       |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |      No       |    |
+|           List::Edit            |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |    |
+|          List::Delete           |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |    |
+|       List::AssignMember        |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |      No       |    |
+|      List::UnassignMember       |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |      No       |    |
+|       List::FetchMembers        |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |    |
+| Timeline::FetchConversationList |      Yes      |         No          |     Yes     |            Yes            |             Yes             |      No       |      No       |    |
+|   Timeline::FetchConversation   |      Yes      |         No          |     Yes     | Yes*(Role:Normalなアカウントのみ) | Yes*(Role:Admin**以外**に実行可能) |      No       |      No       |    |
+
+### Notification
+
+|               操作                | Status:Active | Status:NotActivated | Role:Normal | Role:Moderator | Role:Admin | Frozen:Frozen | Not Signed in | 備考 |
+|:-------------------------------:|:-------------:|:-------------------:|:-----------:|:--------------:|:----------:|:-------------:|:-------------:|:--:|
+| Notification::FetchNotification |      Yes      |         No          |     Yes     |      Yes       |    Yes     |      No       |      No       |    |
+|    Notification::MarkAsRead     |      Yes      |         No          |     Yes     |      Yes       |    Yes     |      No       |      No       |    |
+
+
+
+
+
+
+
+


### PR DESCRIPTION
close #10 

## 概要
- アクセス制御表を追加しました
  - v0.1で実装されるすべての操作について，どの状態のアカウントであれば実行可能であるかを示したものです

## 追加情報
- 網羅的ではないのでもう少し詰めたい感じがあります
